### PR TITLE
Fix import path for bitcask

### DIFF
--- a/docs/bitcask.adoc
+++ b/docs/bitcask.adoc
@@ -2,7 +2,7 @@
 :toc:
 :toc-placement!:
 
-Wrapper to https://github.com/prologic/bitcask[Bitcask].
+Wrapper to https://git.mills.io/prologic/bitcask[Bitcask].
 
 [NOTE]
 ====

--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/mitchellh/mapstructure v1.4.1 // indirect
 	github.com/oklog/ulid/v2 v2.0.2
 	github.com/pierrec/lz4 v2.6.0+incompatible
-	github.com/prologic/bitcask v0.3.10
+	git.mills.io/prologic/bitcask v0.3.10
 	github.com/rs/zerolog v1.21.0
 	github.com/segmentio/ksuid v1.0.3
 	github.com/slack-go/slack v0.9.0

--- a/go.sum
+++ b/go.sum
@@ -203,8 +203,8 @@ github.com/plar/go-adaptive-radix-tree v1.0.4/go.mod h1:Ot8d28EII3i7Lv4PSvBlF8ej
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/posener/complete v1.1.1/go.mod h1:em0nMJCgc9GFtwrmVmEMR/ZL6WyhyjMBndrE9hABlRI=
-github.com/prologic/bitcask v0.3.10 h1:HXygU8zCvW5gLpZ8aQECPk5iV/YQ3hcqdg/zVeES6s0=
-github.com/prologic/bitcask v0.3.10/go.mod h1:8RKJdbHLE7HFGLYSGu9slnYXSV7DMIucwVkaIYOk9GY=
+git.mills.io/prologic/bitcask v0.3.10 h1:HXygU8zCvW5gLpZ8aQECPk5iV/YQ3hcqdg/zVeES6s0=
+git.mills.io/prologic/bitcask v0.3.10/go.mod h1:8RKJdbHLE7HFGLYSGu9slnYXSV7DMIucwVkaIYOk9GY=
 github.com/prometheus/client_golang v0.9.1/go.mod h1:7SWBe2y4D6OKWSNQJUaRYU/AaXPKyh/dDVn+NZz0KFw=
 github.com/prometheus/client_golang v0.9.3/go.mod h1:/TN21ttK/J9q6uSwhBd54HahCDft0ttaMvbicHlPoso=
 github.com/prometheus/client_model v0.0.0-20180712105110-5c3871d89910/go.mod h1:MbSGuTsp3dbXC40dX6PRTWyKYBIrTGTE9sqQNg2J8bo=

--- a/internal/bitcask.go
+++ b/internal/bitcask.go
@@ -1,7 +1,7 @@
 package ll
 
 import (
-	"github.com/prologic/bitcask"
+	"git.mills.io/prologic/bitcask"
 	"github.com/yuin/gopher-lua"
 )
 

--- a/tests/bitcask.lua
+++ b/tests/bitcask.lua
@@ -7,7 +7,7 @@ local db
 --# :toc:
 --# :toc-placement!:
 --#
---# Wrapper to https://github.com/prologic/bitcask[Bitcask].
+--# Wrapper to https://git.mills.io/prologic/bitcask[Bitcask].
 --#
 --# [NOTE]
 --# ====


### PR DESCRIPTION
Project has moved to [git.mills.io/prologic/bitcask](https://git.mills.io/prologic/bitcask).

For details on why see: https://github.com/prologic

Thank you! 🙇